### PR TITLE
[12.0] [FIX] Few fixes to solve warnings:

### DIFF
--- a/account_financial_report/models/account_group.py
+++ b/account_financial_report/models/account_group.py
@@ -22,7 +22,7 @@ class AccountGroup(models.Model):
     compute_account_ids = fields.Many2many(
         'account.account',
         compute='_compute_group_accounts',
-        string="Accounts", store=True)
+        string="Compute accounts", store=True)
 
     @api.multi
     @api.depends('parent_id', 'parent_id.level')

--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -6,6 +6,7 @@ from odoo import models
 
 class AbstractReport(models.AbstractModel):
     _name = 'account_financial_report_abstract'
+    _description = 'Abstract Report'
 
     def _transient_clean_rows_older_than(self, seconds):
         assert self._transient, \

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -715,7 +715,8 @@ class ReportJournalLedgerMoveLine(models.TransientModel):
         ondelete='cascade',
     )
     account_id = fields.Many2one(
-        comodel_name='account.account'
+        comodel_name='account.account',
+        string='Account ID',
     )
     account = fields.Char()
     account_code = fields.Char()
@@ -723,6 +724,7 @@ class ReportJournalLedgerMoveLine(models.TransientModel):
     partner = fields.Char()
     partner_id = fields.Many2one(
         comodel_name='res.partner',
+        string='Partner ID',
     )
     date = fields.Date()
     entry = fields.Char()

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -91,10 +91,10 @@ class TrialBalanceReportAccount(models.TransientModel):
         index=True
     )
     child_account_ids = fields.Char(
-        string="Accounts")
+        string="Child accounts")
     compute_account_ids = fields.Many2many(
         'account.account',
-        string="Accounts", store=True)
+        string="Compute accounts", store=True)
 
     # Data fields, used for report display
     code = fields.Char()

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -64,7 +64,8 @@ class VATReportTaxTags(models.TransientModel):
     # Data fields, used to browse report data
     tax_ids = fields.One2many(
         comodel_name='report_vat_report_tax',
-        inverse_name='report_tax_id'
+        inverse_name='report_tax_id',
+        string='Taxes'
     )
 
 
@@ -82,7 +83,8 @@ class VATReportTax(models.TransientModel):
     # Data fields, used to keep link with real object
     tax_id = fields.Many2one(
         'account.tax',
-        index=True
+        index=True,
+        string='Tax ID',
     )
 
     # Data fields, used for report display

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -61,7 +61,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
     )
     analytic_tag_ids = fields.Many2many(
         comodel_name='account.analytic.tag',
-        string='Filter accounts',
+        string='Filter analytic tags',
     )
     account_journal_ids = fields.Many2many(
         comodel_name='account.journal',

--- a/account_financial_report/wizard/vat_report_wizard.py
+++ b/account_financial_report/wizard/vat_report_wizard.py
@@ -9,6 +9,7 @@ from odoo.exceptions import ValidationError
 
 class VATReportWizard(models.TransientModel):
     _name = "vat.report.wizard"
+    _description = "VAT Report Wizard"
 
     company_id = fields.Many2one(
         comodel_name='res.company',


### PR DESCRIPTION
- _description in account_financial_report_abstract
- _description in vat.report.wizard
- Two fields using same label 'Accounts' in account.group
- Two fields using same label 'Account' in report_journal_ledger_move_line
- Two fields using same label 'Partner' in report_journal_ledger_move_line
- Two fields using same label 'Accounts' in report_trial_balance_account
- Two fields using same label 'Tax' in report_vat_report_taxtag
- Two fields using same label 'Tax' in report_vat_report_tax
- Two fields using same label 'Filter accounts' in general.ledger.report.wizard